### PR TITLE
Fixed OOI credentials script for day 1 by adding `cd ~`

### DIFF
--- a/scripts/setup_ooi_creds.sh
+++ b/scripts/setup_ooi_creds.sh
@@ -1,5 +1,6 @@
 # Set your OOINet credentials (make sure to replace API_Username and
 # API_Token below with your credentials!!)
+cd ~
 touch .netrc
 chmod 600 .netrc
 cat <<EOT >> .netrc


### PR DESCRIPTION
As title says. This will be the only change to reduce time required to review.